### PR TITLE
Add sample Program demonstrating library usage

### DIFF
--- a/samples/Program.cs
+++ b/samples/Program.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using textgen;
+
+class Program
+{
+    static async Task Main()
+    {
+        // API endpoint and API key
+        string host = "https://api.openai.com/v1/chat/completions";
+        string apiKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY") ?? "YOUR_API_KEY";
+
+        using var httpClient = new HttpClient();
+        if (!string.IsNullOrEmpty(apiKey))
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        // Create a text generator using the factory
+        var generator = TextGeneratorFactory.CreateGenerator(host, httpClient);
+        if (generator == null)
+        {
+            Console.WriteLine("Unsupported API endpoint.");
+            return;
+        }
+
+        // Create default configuration for the generator
+        var config = generator.CreateDefaultConfig();
+
+        string model = "gpt-4o-mini";
+        string systemPrompt = "You are a helpful assistant.";
+        string userPrompt = "Hello!";
+
+        // Generate text
+        var result = await generator.GenerateTextAsync(model, userPrompt, systemPrompt, config, new OutputResult());
+
+        Console.WriteLine(result.Completion);
+    }
+}

--- a/textgen.csproj
+++ b/textgen.csproj
@@ -12,4 +12,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
+  <!-- Exclude sample code from build -->
+  <ItemGroup>
+    <Compile Remove="samples/**" />
+    <None Include="samples/**" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add `samples/Program.cs` showing how to call the text generation library from an external app
- exclude the `samples` directory from compilation in `textgen.csproj`

## Testing
- `~/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a56b52e9888322b51e2e4e3e0bb90a